### PR TITLE
Fix issue with filenames with plupload 2.1.2

### DIFF
--- a/Westwind.plUploadHandler/plUploadBaseHandler.cs
+++ b/Westwind.plUploadHandler/plUploadBaseHandler.cs
@@ -57,7 +57,7 @@ public abstract class plUploadBaseHandler : IHttpHandler
             HttpPostedFile fileUpload = Request.Files[0];
 
             string fileName = fileUpload.FileName;
-            if (string.IsNullOrEmpty(fileName))
+            if (string.IsNullOrEmpty(fileName) || string.Equals(fileName,"blob"))
                 fileName = Request["name"] ?? string.Empty;
 
             // normalize file name to avoid directory traversal attacks            


### PR DESCRIPTION
With m0xie v1.2.1 and plupload 2.1.2 the filename from
fileUpload.FileName comes through as "blob" and this causes the
extension check to fail.
![blobfilename](https://cloud.githubusercontent.com/assets/78284/3697958/46fa9228-13b5-11e4-98b5-6f66fd7d4759.JPG)
