### PR TITLE
plUploadFileHandler: send the filename back to client when upload is com...

### DIFF
--- a/Westwind.plUploadHandler/plUploadFileHandler.cs
+++ b/Westwind.plUploadHandler/plUploadFileHandler.cs
@@ -96,5 +96,14 @@ namespace Westwind.plUpload
 
             return true;
         }
+
+        /// <summary>
+        /// Puts the filename in the response
+        /// </summary>
+        /// <param name="fileName"></param>
+        protected override void OnUploadCompleted(string fileName)
+        {
+            WriteSucessResponse(fileName);
+        }
     }
 }


### PR DESCRIPTION
...plete

I noticed that `OnUploadCompleted` is not overriden in `plUploadFileHandler`. This means that, when it's called in `ProcessRequest`, nothing happens. It would be nice to send the filename back to the client. I added that to `plUploadFileHandler`.
I could just as well have inherited from `plUploadFileHandler`, but I think it's nicer to have this in `plUploadFileHandler` itself.

Sincerely,
Bart
